### PR TITLE
Exposing ingress class and prefix to be configurable

### DIFF
--- a/bmrg-flow/Chart.yaml
+++ b/bmrg-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: bmrg-flow
 description: Boomerang Flow
-version: 3.0.9
+version: 3.0.10
 appVersion: 2.3.0
 home: https://useboomerang.io
 keywords:

--- a/bmrg-flow/README.md
+++ b/bmrg-flow/README.md
@@ -104,6 +104,8 @@ The following table lists the configurable parameters of the chart and their def
 | `auth.enabled` | Enable addition of auth annotations on ingress | `true`
 | `auth.url.internal` |  | `http://bmrg-auth-proxy-bmrg-auth-proxy-4180/oauth/auth`
 | `auth.url.external` |  | `https://$host/oauth/start?rd=$uri`
+| `annotationsPrefix` | The prefix for the annotations inside the ingress definition. Typically for IKS Community Ingress you need to set it to "nginx.ingress.kubernetes.io" | `ingress.kubernetes.io`
+| `class` | The class of the ingress, it is used to mark the ingress resources to be picked-up by a specific controller. For IKS Community Ingress set it to "public-iks-k8s-nginx" | `nginx`
 
 ### Database Configuration
 

--- a/bmrg-flow/requirements.yaml
+++ b/bmrg-flow/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: bmrg-common
     repository: https://tools.boomerangplatform.net/artifactory/boomeranglib-helm
-    version: ~0.5.1
+    version: ~0.5.2
     alias: bmrgcommon

--- a/bmrg-flow/templates/ingress-app.yaml
+++ b/bmrg-flow/templates/ingress-app.yaml
@@ -13,13 +13,13 @@ metadata:
   annotations:
     {{- if eq $.Values.auth.enabled true }}
     {{- include "bmrg.ingress.config.auth_proxy_auth_annotations" $ | nindent 4 }}
-    ingress.kubernetes.io/configuration-snippet: |
+    {{ $.Values.ingress.annotationsPrefix}}/configuration-snippet: |
       {{- include "bmrg.ingress.config.auth_proxy_access_control" $ | nindent 6 }}
       {{- include "bmrg.ingress.config.auth_proxy_authorization" $ | nindent 6 }}
     {{- end }}
-    ingress.kubernetes.io/ssl-redirect: "true"
-    ingress.kubernetes.io/client-max-body-size: 1m
-    kubernetes.io/ingress.class: nginx
+    {{ $.Values.ingress.annotationsPrefix}}/ssl-redirect: "true"
+    {{ $.Values.ingress.annotationsPrefix}}/client-max-body-size: 1m
+    kubernetes.io/ingress.class: {{ $.Values.ingress.class}}
 spec:
   rules:
     - host: {{ $.Values.ingress.host }}

--- a/bmrg-flow/templates/ingress-service-listener.yaml
+++ b/bmrg-flow/templates/ingress-service-listener.yaml
@@ -11,11 +11,11 @@ metadata:
   labels:
     {{- include "bmrg.labels.chart" (dict "context" $ "tier" $tier "component" $k ) | nindent 4 }}
   annotations:
-    ingress.kubernetes.io/auth-url: "{{ $.Values.auth.tokenURL }}"
-    ingress.kubernetes.io/ssl-redirect: "false"
-    ingress.kubernetes.io/rewrite-target: /{{ $k }}/$2
-    ingress.kubernetes.io/client-max-body-size: 1m
-    kubernetes.io/ingress.class: nginx
+    {{ $.Values.ingress.annotationsPrefix}}/auth-url: "{{ $.Values.auth.tokenURL }}"
+    {{ $.Values.ingress.annotationsPrefix}}/ssl-redirect: "false"
+    {{ $.Values.ingress.annotationsPrefix}}/rewrite-target: /{{ $k }}/$2
+    {{ $.Values.ingress.annotationsPrefix}}/client-max-body-size: 1m
+    kubernetes.io/ingress.class: {{ $.Values.ingress.class}}
 spec:
   rules:
     - host: {{ $.Values.ingress.host }}

--- a/bmrg-flow/templates/ingress-service.yaml
+++ b/bmrg-flow/templates/ingress-service.yaml
@@ -12,12 +12,12 @@ metadata:
     {{- include "bmrg.labels.chart" (dict "context" $ "tier" $tier "component" $k ) | nindent 4 }}
   annotations:
     {{- if eq $k "flow" }}
-    ingress.kubernetes.io/proxy-connect-timeout: "600"
+    {{ $.Values.ingress.annotationsPrefix}}/proxy-connect-timeout: "600"
     {{- end }}
     {{- if and (ne $k "webhook") (eq $.Values.auth.enabled true) }}
     {{- include "bmrg.ingress.config.auth_proxy_auth_annotations" $ | nindent 4 }}
     {{- end }}
-    ingress.kubernetes.io/configuration-snippet: |
+    {{ $.Values.ingress.annotationsPrefix}}/configuration-snippet: |
       {{- if and (ne $k "webhook") (eq $.Values.auth.enabled true) }}
       {{- include "bmrg.ingress.config.auth_proxy_access_control" $ | nindent 6 }}
       {{- include "bmrg.ingress.config.auth_proxy_authorization" $ | nindent 6 }}
@@ -31,10 +31,10 @@ metadata:
       add_header 'Content-Length' 0;
       add_header 'Content-Type' 'text/plain charset=UTF-8';
       return 204;}
-    ingress.kubernetes.io/ssl-redirect: "false"
-    ingress.kubernetes.io/rewrite-target: /{{ $k }}/$2
-    ingress.kubernetes.io/client-max-body-size: 1m
-    kubernetes.io/ingress.class: nginx
+    {{ $.Values.ingress.annotationsPrefix}}/ssl-redirect: "false"
+    {{ $.Values.ingress.annotationsPrefix}}/rewrite-target: /{{ $k }}/$2
+    {{ $.Values.ingress.annotationsPrefix}}/client-max-body-size: 1m
+    kubernetes.io/ingress.class: {{ $.Values.ingress.class}}
 spec:
   rules:
     - host: {{ $.Values.ingress.host }}

--- a/bmrg-flow/values.yaml
+++ b/bmrg-flow/values.yaml
@@ -100,6 +100,12 @@ ingress:
   root: /flow
   host: cloud.boomerangplatform.net
   tlsSecretName: bmrg-tls-cloud
+  # The prefix for the annotations inside the ingress definition. Typically for IKS Community Ingress
+  # you need to set it to "nginx.ingress.kubernetes.io"
+  annotationsPrefix: "ingress.kubernetes.io"
+  # The class of the ingress, it is used to mark the ingress resources to be picked-up by a specific 
+  # controller. For IKS Community Ingress set it to "public-iks-k8s-nginx"
+  class: "nginx"
 
 auth:
   enabled: false


### PR DESCRIPTION
Closes #

For this library to work correctly with IKS Community Ingress it needs to create the Ingress resources with a specific nginx class and nginx prefixed annotations. 
Thus, these options should be configurable to support different Ingress controllers. 

#### Changelog

**New**

- Exposed `ingress.annotationsPrefix` and `ingress.class` to allow the setting them up during the installation for different Ingress controllers.  

**Changed**

- The ingress annotations section.

**Removed**

- Nothing

#### Testing / Reviewing

Deployed in an IKS Cluster with IKS Community Ingress.
